### PR TITLE
make func Entry.MergedFields public

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -265,8 +265,8 @@ func (e *Entry) Stop(err *error) {
 	}
 }
 
-// mergedFields returns the fields list collapsed into a single one.
-func (e *Entry) mergedFields() Fields {
+// MergedFields returns the fields list collapsed into a single one.
+func (e *Entry) MergedFields() Fields {
 	f := Fields{}
 
 	for _, fields := range e.fields {
@@ -284,7 +284,7 @@ func (e *Entry) finalize(level Level, msg string, pool bool) *Entry {
 		// note: async entry cannot be taken from the pool since some handlers
 		//       (e.g. memory handler) keep entries
 		ret := newEntry(e.Logger)
-		ret.Fields = e.mergedFields()
+		ret.Fields = e.MergedFields()
 		ret.Level = level
 		ret.Message = msg
 		ret.Timestamp = Now()
@@ -292,7 +292,7 @@ func (e *Entry) finalize(level Level, msg string, pool bool) *Entry {
 	}
 	return &Entry{
 		Logger:    e.Logger,
-		Fields:    e.mergedFields(),
+		Fields:    e.MergedFields(),
 		Level:     level,
 		Message:   msg,
 		Timestamp: Now(),

--- a/entry_test.go
+++ b/entry_test.go
@@ -13,8 +13,8 @@ func TestEntry_WithFields(t *testing.T) {
 	assert.Nil(t, a.Fields)
 
 	b := a.WithFields(Fields{{Name: "foo", Value: "bar"}})
-	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{{Name: "foo", Value: "bar"}}, b.mergedFields())
+	assert.Equal(t, Fields{}, a.MergedFields())
+	assert.Equal(t, Fields{{Name: "foo", Value: "bar"}}, b.MergedFields())
 
 	c := a.WithFields(Fields{{Name: "foo", Value: "hello"}, {Name: "bar", Value: "world"}})
 
@@ -28,38 +28,38 @@ func TestEntry_WithFields(t *testing.T) {
 func TestEntry_WithField(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithField("foo", "bar")
-	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{{Name: "foo", Value: "bar"}}, b.mergedFields())
+	assert.Equal(t, Fields{}, a.MergedFields())
+	assert.Equal(t, Fields{{Name: "foo", Value: "bar"}}, b.MergedFields())
 }
 
 func TestEntry_WithError(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithError(fmt.Errorf("boom"))
-	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{{Name: "error", Value: "boom"}}, b.mergedFields())
+	assert.Equal(t, Fields{}, a.MergedFields())
+	assert.Equal(t, Fields{{Name: "error", Value: "boom"}}, b.MergedFields())
 }
 
 func TestEntry_WithError_fields(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithError(errFields("boom"))
-	assert.Equal(t, Fields{}, a.mergedFields())
+	assert.Equal(t, Fields{}, a.MergedFields())
 	assert.Equal(t, Fields{
 		{Name: "error", Value: "boom"},
 		{Name: "reason", Value: "timeout"},
-	}, b.mergedFields())
+	}, b.MergedFields())
 }
 
 func TestEntry_WithError_nil(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithError(nil)
-	assert.Equal(t, Fields{}, a.mergedFields())
-	assert.Equal(t, Fields{}, b.mergedFields())
+	assert.Equal(t, Fields{}, a.MergedFields())
+	assert.Equal(t, Fields{}, b.MergedFields())
 }
 
 func TestEntry_WithDuration(t *testing.T) {
 	a := NewEntry(nil)
 	b := a.WithDuration(time.Second * 2)
-	assert.Equal(t, Fields{{Name: "duration", Value: int64(2000)}}, b.mergedFields())
+	assert.Equal(t, Fields{{Name: "duration", Value: int64(2000)}}, b.MergedFields())
 }
 
 type errFields string


### PR DESCRIPTION
Export func `MergedFields` in `Entry` to ease copying an Entry. 